### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Detronict/d9f08575-2497-4a91-8eb2-b02637b117e9/594a2c65-0191-4728-a85d-c6a2d07ded18/_apis/work/boardbadge/28281f38-436a-45e0-857a-4cba9e61e1aa)](https://dev.azure.com/Detronict/d9f08575-2497-4a91-8eb2-b02637b117e9/_boards/board/t/594a2c65-0191-4728-a85d-c6a2d07ded18/Microsoft.RequirementCategory)
 
 # Contributing
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#2. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.